### PR TITLE
Add homepage map unit tests

### DIFF
--- a/__tests__/components/GoogleMap.test.tsx
+++ b/__tests__/components/GoogleMap.test.tsx
@@ -45,4 +45,10 @@ describe('GoogleMap', () => {
     render(<GoogleMap markers={mockMarkers} center={mockCenter} />);
     expect((window as any).google.maps.Marker).toHaveBeenCalledTimes(mockMarkers.length);
   });
+
+  it('uses provided zoom level', () => {
+    render(<GoogleMap markers={mockMarkers} center={mockCenter} zoom={8} />);
+    const call = (window as any).google.maps.Map.mock.calls[0][1];
+    expect(call.zoom).toBe(8);
+  });
 });

--- a/__tests__/components/HomepageMap.test.tsx
+++ b/__tests__/components/HomepageMap.test.tsx
@@ -1,0 +1,35 @@
+import { render } from '@testing-library/react';
+import HomepageMap from '@/components/Homepage/HomepageMap';
+
+jest.mock('@/components/MapComponent/GoogleMap', () => (props: any) => {
+  (globalThis as any).googleMapProps = props;
+  return <div data-testid="map" />;
+});
+
+jest.mock('@/data/locations.json', () => [
+  { key: 'public', name: 'Public', latitude: 53, longitude: -2, isPublic: true },
+  { key: 'private', name: 'Private', latitude: 54, longitude: -3, isPublic: false },
+]);
+
+describe('HomepageMap', () => {
+  it('passes only public locations to GoogleMap', () => {
+    render(<HomepageMap />);
+    const markers = (globalThis as any).googleMapProps.markers;
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toMatchObject({
+      id: 'public',
+      lat: 53,
+      lng: -2,
+      title: 'Public',
+      link: '/public',
+    });
+  });
+
+  it('uses fixed map centre', () => {
+    render(<HomepageMap />);
+    expect((globalThis as any).googleMapProps.center).toEqual({
+      lat: 53.4098,
+      lng: -2.1576,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- unit test HomepageMap component with mocked data
- test zoom option in GoogleMap tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846b62210a48324b2590da2229896ad