### PR TITLE
Add organisation unit tests

### DIFF
--- a/__tests__/components/FindHelpResults.test.tsx
+++ b/__tests__/components/FindHelpResults.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import FindHelpResults from '@/components/FindHelp/FindHelpResults';
-import { LocationProvider } from '@/contexts/LocationContext';
+import { LocationProvider, LocationContext, type LocationState } from '@/contexts/LocationContext';
 import { FilterContextProvider } from '@/contexts/FilterContext';
 import { act as reactAct } from 'react';
 
@@ -9,12 +9,23 @@ jest.mock('@/components/FindHelp/FilterPanel', () =>
   require('../../__mocks__/FilterPanel.tsx')
 );
 
-function renderWithProviders(ui: React.ReactElement) {
-  return render(
-    <LocationProvider>
-      <FilterContextProvider>{ui}</FilterContextProvider>
-    </LocationProvider>
+jest.mock('@/components/MapComponent/GoogleMap', () => (props: any) => {
+  (globalThis as any).googleMapProps = props;
+  return <div data-testid="google-map" />;
+});
+
+function renderWithProviders(
+  ui: React.ReactElement,
+  location: LocationState | null = null
+) {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <LocationContext.Provider
+      value={{ location, setLocation: jest.fn(), requestLocation: jest.fn() }}
+    >
+      <FilterContextProvider>{children}</FilterContextProvider>
+    </LocationContext.Provider>
   );
+  return render(<Wrapper>{ui}</Wrapper>);
 }
 
 describe('FindHelpResults', () => {
@@ -56,5 +67,56 @@ describe('FindHelpResults', () => {
     await waitFor(() => {
       expect(screen.getByText(/No services found within/i)).toBeInTheDocument();
     });
+  });
+
+  it('sorts services alphabetically when selected', async () => {
+    const providers = [
+      {
+        id: '1',
+        name: 'Alpha Org',
+        slug: 'alpha',
+        services: [
+          { id: 'a1', name: 'Alpha Service', category: 'health', subCategory: 'gp', description: '', latitude: 0, longitude: 0, clientGroups: [], openTimes: [] },
+        ],
+      },
+      {
+        id: '2',
+        name: 'Beta Org',
+        slug: 'beta',
+        services: [
+          { id: 'b1', name: 'Beta Service', category: 'health', subCategory: 'gp', description: '', latitude: 0.01, longitude: 0.01, clientGroups: [], openTimes: [] },
+        ],
+      },
+    ];
+
+    const { container } = renderWithProviders(
+      <FindHelpResults providers={providers as any} />,
+      { lat: 0, lng: 0 }
+    );
+
+    fireEvent.change(screen.getByLabelText(/Sort by/i), { target: { value: 'alpha' } });
+
+    const headings = container.querySelectorAll('h2');
+    expect(headings[0].textContent).toBe('Alpha Service');
+    expect(headings[1].textContent).toBe('Beta Service');
+  });
+
+  it('passes user location marker to GoogleMap', async () => {
+    const providers = [
+      {
+        id: '1',
+        name: 'Test Org',
+        slug: 'test',
+        services: [
+          { id: 's1', name: 'S1', category: 'health', subCategory: 'gp', description: '', latitude: 0, longitude: 0, clientGroups: [], openTimes: [] },
+        ],
+      },
+    ];
+
+    renderWithProviders(<FindHelpResults providers={providers as any} />, { lat: 0, lng: 0 });
+    fireEvent.click(screen.getByRole('button', { name: /show map/i }));
+    const markers = (globalThis as any).googleMapProps.markers;
+    expect(markers[0].id).toBe('user-location');
+    expect(markers).toHaveLength(2);
   });
 });

--- a/__tests__/components/OrganisationContactBlock.test.tsx
+++ b/__tests__/components/OrganisationContactBlock.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import OrganisationContactBlock from '@/components/OrganisationPage/OrganisationContactBlock';
+
+describe('OrganisationContactBlock', () => {
+  it('mentions organisation name in message', () => {
+    render(<OrganisationContactBlock organisation={{ name: 'Org A' } as any} />);
+    expect(
+      screen.getByText(/We do not currently have public contact details for Org A./i)
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/OrganisationFooter.test.tsx
+++ b/__tests__/components/OrganisationFooter.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import OrganisationFooter from '@/components/OrganisationPage/OrganisationFooter';
+
+describe('OrganisationFooter', () => {
+  it('renders disclaimer text', () => {
+    render(<OrganisationFooter />);
+    expect(screen.getByText(/Information provided by Street Support/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/OrganisationLocations.test.tsx
+++ b/__tests__/components/OrganisationLocations.test.tsx
@@ -1,0 +1,45 @@
+import { render } from '@testing-library/react';
+import OrganisationLocations from '@/components/OrganisationPage/OrganisationLocations';
+
+jest.mock('@/components/MapComponent/GoogleMap', () => (props: any) => {
+  (globalThis as any).mapProps = props;
+  return <div data-testid="map" />;
+});
+
+const baseOrg: any = {
+  id: '1',
+  name: 'Loc Org',
+  slug: 'loc-org',
+  postcode: '',
+  latitude: 53,
+  longitude: -2,
+  verified: true,
+  published: true,
+  disabled: false,
+};
+
+describe('OrganisationLocations', () => {
+  it('returns null when coordinates missing', () => {
+    const { container } = render(
+      <OrganisationLocations organisation={{ ...baseOrg, latitude: null }} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders map with provided coordinates', () => {
+    render(<OrganisationLocations organisation={baseOrg} />);
+    expect((globalThis as any).mapProps.center).toEqual({ lat: 53, lng: -2 });
+    expect((globalThis as any).mapProps.markers[0]).toMatchObject({
+      id: '1',
+      lat: 53,
+      lng: -2,
+      title: 'Loc Org',
+      organisationSlug: 'loc-org',
+    });
+  });
+
+  it('uses default slug when none provided', () => {
+    render(<OrganisationLocations organisation={{ ...baseOrg, slug: undefined }} />);
+    expect((globalThis as any).mapProps.markers[0].organisationSlug).toBe('org-loc-default');
+  });
+});

--- a/__tests__/components/OrganisationOverview.test.tsx
+++ b/__tests__/components/OrganisationOverview.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import OrganisationOverview from '@/components/OrganisationPage/OrganisationOverview';
+
+const organisation: any = {
+  id: '1',
+  name: 'Helpful Org',
+  slug: 'helpful',
+  postcode: '',
+  latitude: 53.1,
+  longitude: -2.1,
+  verified: true,
+  published: true,
+  disabled: false,
+  services: [
+    { id: 's1', name: 'A', category: 'training', subCategory: 'skill', description: '', openTimes: [], clientGroups: [], latitude: 0, longitude: 0 },
+    { id: 's2', name: 'B', category: 'employment', subCategory: 'jobs', description: '', openTimes: [], clientGroups: [], latitude: 0, longitude: 0 },
+    { id: 's3', name: 'C', category: 'training', subCategory: 'skill', description: '', openTimes: [], clientGroups: [], latitude: 0, longitude: 0 },
+  ],
+};
+
+describe('OrganisationOverview', () => {
+  it('renders organisation name and unique category tags', () => {
+    render(<OrganisationOverview organisation={organisation} />);
+    expect(screen.getByText('Helpful Org')).toBeInTheDocument();
+    expect(screen.getByText('training')).toBeInTheDocument();
+    expect(screen.getByText('employment')).toBeInTheDocument();
+    expect(screen.getAllByText('training')).toHaveLength(1);
+  });
+});

--- a/__tests__/components/OrganisationServicesAccordion.test.tsx
+++ b/__tests__/components/OrganisationServicesAccordion.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import OrganisationServicesAccordion from '@/components/OrganisationPage/OrganisationServicesAccordion';
+
+jest.mock('@/components/ui/Accordion', () => ({ title, children, className }: any) => (
+  <div data-testid="accordion" data-title={title} className={className}>{children}</div>
+));
+
+jest.mock('@/components/FindHelp/ServiceCard', () => ({ service }: any) => (
+  <div data-testid="service-card">{service.name}</div>
+));
+
+describe('OrganisationServicesAccordion', () => {
+  it('returns null when no services', () => {
+    const { container } = render(
+      <OrganisationServicesAccordion organisation={{ groupedServices: {} } as any} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders grouped services inside accordions', () => {
+    const org: any = {
+      groupedServices: {
+        training: [{ id: 'a', name: 'Train' }],
+        employment: [{ id: 'b', name: 'Job1' }, { id: 'c', name: 'Job2' }],
+      },
+    };
+    render(<OrganisationServicesAccordion organisation={org} />);
+    expect(screen.getByText('Services')).toBeInTheDocument();
+    const accs = screen.getAllByTestId('accordion');
+    expect(accs).toHaveLength(2);
+    expect(accs[0]).toHaveAttribute('data-title', 'training');
+    expect(screen.getAllByTestId('service-card')).toHaveLength(3);
+  });
+});

--- a/__tests__/utils/organisation.test.ts
+++ b/__tests__/utils/organisation.test.ts
@@ -1,0 +1,56 @@
+import { getOrganisationBySlug } from '@/utils/organisation';
+
+jest.mock('@/data/service-providers.json', () => [
+  {
+    id: '1',
+    name: 'Mock Org',
+    slug: 'mock-org',
+    postcode: '',
+    latitude: 53,
+    longitude: -2,
+    verified: true,
+    published: true,
+    disabled: false,
+    services: [
+      {
+        id: 'a',
+        name: 'Service A',
+        category: 'training',
+        subCategory: 'skill',
+        description: '',
+        openTimes: [],
+        clientGroups: [],
+        latitude: 53,
+        longitude: -2,
+      },
+      {
+        id: 'b',
+        name: 'Service B',
+        category: undefined,
+        subCategory: 'misc',
+        description: '',
+        openTimes: [],
+        clientGroups: [],
+        latitude: 53,
+        longitude: -2,
+      },
+    ],
+  },
+]);
+
+describe('getOrganisationBySlug', () => {
+  it('returns organisation with grouped services when found', () => {
+    const org = getOrganisationBySlug('mock-org');
+    expect(org?.name).toBe('Mock Org');
+    expect(org?.groupedServices.training).toHaveLength(1);
+    expect(org?.groupedServices.Other).toHaveLength(1);
+    expect(org?.groupedServices.training[0]).toMatchObject({
+      organisation: 'Mock Org',
+      organisationSlug: 'mock-org',
+    });
+  });
+
+  it('returns null for unknown slug', () => {
+    expect(getOrganisationBySlug('unknown')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for organisation components and utility function
- extend FindHelpResults tests with additional cases

## Testing
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_684b0bef60f08324bcbeea69e82d940e