### PR TITLE
Improve location search performance

### DIFF
--- a/src/app/find-help/page.tsx
+++ b/src/app/find-help/page.tsx
@@ -1,64 +1,10 @@
 import { LocationProvider } from '@/contexts/LocationContext';
-import FindHelpEntry from '@/components/FindHelp/FindHelpEntry';
-import FindHelpResults from '@/components/FindHelp/FindHelpResults';
-import type { UIFlattenedService } from '@/types';
-import { decodeHtmlEntities } from '@/utils/htmlDecode';
-import { categoryKeyToName, subCategoryKeyToName } from '@/utils/categoryLookup';
+import FindHelpContainer from '@/components/FindHelp/FindHelpContainer';
 
-export default async function FindHelpPage() {
-  // ✅ Use absolute URL for server fetch, relative for client
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
-
-  const res = await fetch(`${baseUrl}/api/services?limit=1000`, { cache: 'no-store' });
-
-  if (!res.ok) {
-    throw new Error(`Failed to fetch services: ${res.status}`);
-  }
-
-  const raw = await res.json();
-  const rawArray = raw.results || [];
-
-  if (!Array.isArray(rawArray)) {
-    throw new Error('API did not return an array in "results"!');
-  }
-
-  const services: UIFlattenedService[] = rawArray.map((item: any) => {
-    const coords = item.Address?.Location?.coordinates || [0, 0];
-    return {
-      id: item._id || item.id,
-      name: decodeHtmlEntities(item.ServiceProviderName || item.name || ''),
-      description: decodeHtmlEntities(item.Info || item.description || ''),
-      category: item.ParentCategoryKey || item.category || '',
-      categoryName:
-        categoryKeyToName[item.ParentCategoryKey] ||
-        item.ParentCategoryKey ||
-        '',
-      subCategory: item.SubCategoryKey || item.subCategory || '',
-      subCategoryName:
-        subCategoryKeyToName[item.SubCategoryKey] ||
-        item.SubCategoryKey ||
-        '',
-      latitude: coords[1],
-      longitude: coords[0],
-      organisation: {
-        name: decodeHtmlEntities(
-          item.organisation?.name || item.ServiceProviderName || ''
-        ),
-        slug: item.organisation?.slug || item.ServiceProviderKey || '',
-        isVerified: item.organisation?.isVerified || false,
-      },
-      organisationSlug: item.organisation?.slug || item.ServiceProviderKey || '',
-      clientGroups: item.ClientGroups || [],
-      openTimes: item.OpeningTimes || [],
-    };
-  });
-
+export default function FindHelpPage() {
   return (
     <LocationProvider>
-      <div>
-        <FindHelpEntry />
-        <FindHelpResults services={services} />
-      </div>
+      <FindHelpContainer />
     </LocationProvider>
   );
 }

--- a/src/components/FindHelp/FindHelpContainer.tsx
+++ b/src/components/FindHelp/FindHelpContainer.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useLocation } from '@/contexts/LocationContext';
+import FindHelpEntry from './FindHelpEntry';
+import FindHelpResults from './FindHelpResults';
+import type { UIFlattenedService } from '@/types';
+import { decodeHtmlEntities } from '@/utils/htmlDecode';
+import { categoryKeyToName, subCategoryKeyToName } from '@/utils/categoryLookup';
+
+export default function FindHelpContainer() {
+  const { location } = useLocation();
+  const [services, setServices] = useState<UIFlattenedService[]>([]);
+
+  useEffect(() => {
+    if (!location) return;
+
+    async function load() {
+      try {
+        const params = new URLSearchParams({ limit: '50' });
+        if (location.lat != null && location.lng != null) {
+          params.append('lat', location.lat.toString());
+          params.append('lng', location.lng.toString());
+        }
+        const res = await fetch(`/api/services?${params.toString()}`);
+        if (!res.ok) {
+          throw new Error('Failed to fetch services');
+        }
+        const raw = await res.json();
+        const rawArray = raw.results || [];
+        const mapped: UIFlattenedService[] = rawArray.map((item: any) => {
+          const coords = item.Address?.Location?.coordinates || [0, 0];
+          return {
+            id: item._id || item.id,
+            name: decodeHtmlEntities(item.ServiceProviderName || item.name || ''),
+            description: decodeHtmlEntities(item.Info || item.description || ''),
+            category: item.ParentCategoryKey || item.category || '',
+            categoryName:
+              categoryKeyToName[item.ParentCategoryKey] ||
+              item.ParentCategoryKey ||
+              '',
+            subCategory: item.SubCategoryKey || item.subCategory || '',
+            subCategoryName:
+              subCategoryKeyToName[item.SubCategoryKey] ||
+              item.SubCategoryKey ||
+              '',
+            latitude: coords[1],
+            longitude: coords[0],
+            organisation: {
+              name: decodeHtmlEntities(
+                item.organisation?.name || item.ServiceProviderName || ''
+              ),
+              slug: item.organisation?.slug || item.ServiceProviderKey || '',
+              isVerified: item.organisation?.isVerified || false,
+            },
+            organisationSlug: item.organisation?.slug || item.ServiceProviderKey || '',
+            clientGroups: item.ClientGroups || [],
+            openTimes: item.OpeningTimes || [],
+          };
+        });
+        setServices(mapped);
+      } catch (err) {
+        console.error('Failed to fetch services', err);
+        setServices([]);
+      }
+    }
+
+    load();
+  }, [location]);
+
+  return (
+    <div>
+      <FindHelpEntry />
+      <FindHelpResults services={services} />
+    </div>
+  );
+}

--- a/tests/__tests__/api/services.test.ts
+++ b/tests/__tests__/api/services.test.ts
@@ -33,6 +33,23 @@ jest.mock('@/utils/mongodb', () => ({
                   }),
                 }),
               }),
+              aggregate: () => ({
+                toArray: async () => [
+                  {
+                    Key: 'service-1',
+                    ServiceProviderKey: 'org-1',
+                    Title: 'Test Service',
+                    ParentCategoryKey: 'health',
+                    SubCategoryKey: 'gp',
+                    Description: 'Test description',
+                    OpeningTimes: [],
+                    ClientGroups: [],
+                    Address: { City: 'Leeds', Location: { coordinates: [-1,1] } },
+                    IsPublished: true,
+                    distance: 1.2,
+                  },
+                ],
+              }),
             };
           }
 
@@ -87,5 +104,15 @@ describe('GET /api/services', () => {
     expect(json.results[0].organisation.name).toBe('Test Org');
     expect(json.results[0].organisation.slug).toBe('org-1');
     expect(json.results[0].organisation.isVerified).toBe(true);
+  });
+
+  it('supports lat/lng search with distance', async () => {
+    const req = new Request('http://localhost/api/services?lat=53&lng=-1');
+    const res = await GET(req);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.status).toBe('success');
+    expect(Array.isArray(json.results)).toBe(true);
+    expect(json.results[0].distance).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- add `FindHelpContainer` client component to fetch services after geolocation
- reduce server component to just wrapper
- support `lat` and `lng` query params in `/api/services` for geospatial results
- update API tests for new parameters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685531486560832498001c00589a197f